### PR TITLE
win32: MinGW build support

### DIFF
--- a/unifdef.c
+++ b/unifdef.c
@@ -43,7 +43,11 @@
  *   it possible to handle all "dodgy" directives correctly.
  */
 
-#include "unifdef.h"
+#ifdef _WIN32
+	#include "win32/unifdef.h"
+#else
+	#include "unifdef.h"
+#endif
 
 static const char copyright[] =
     #include "version.h"

--- a/win32/Makefile.mingw
+++ b/win32/Makefile.mingw
@@ -1,0 +1,13 @@
+## Build:
+##  mingw32-make -f Makefile.mingw
+
+CFLAGS=-I.
+
+all: unifdef.exe
+
+unifdef.exe: ../unifdef.c win32.c ../FreeBSD/getopt.c ../FreeBSD/err.c
+	$(CC) -o $@ $(CFLAGS) $^
+
+unifdef.exe: version.h
+version.h:
+	echo "" > version.h


### PR DESCRIPTION
Shall you be interested, I added a makefile for building with MinGW on Windows.
The `#ifdef` doesn't look too pretty, but I had no better idea how to do that without much ingerence (maybe moving the original header to new `unix/` subdir and patching the `Makefile` would be better?)
