### PR TITLE
travis: build improvements and minor win32 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,42 @@
 language: c
 
+sudo: false
+
+os:
+  - linux
+  - osx
+
 compiler:
   - gcc
   - clang
 
 matrix:
- include:
-   - compiler: i586-mingw32msvc-gcc
-     env: BUILD_MINGW="yes"
-
-before_install:
-  - sudo apt-get -qq update
+  include:
+    ## Ubuntu 14.04 Trusty (beta), sudo required!
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+      env: TRUSTY="yes"
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+      env: TRUSTY="yes"
+    ## MinGW / wine
+    - os: linux
+      sudo: required
+      compiler: i586-mingw32msvc-gcc
+      env: BUILD_MINGW="yes"
+  allow_failures:
+    - compiler: i586-mingw32msvc-gcc
 
 install:
-  - if test "${BUILD_MINGW}" = "yes"; then sudo apt-get -qq install wine; fi
+  - env | grep -v "encrypted" | LC_ALL=C sort
+  - if test "${BUILD_MINGW}" = "yes"; then
+      sudo apt-get -qq update &&
+      sudo apt-get -qq install wine;
+    fi
 
 script:
   - if test "${BUILD_MINGW}" != "yes"; then
@@ -28,8 +51,9 @@ script:
       make -f win32/Makefile.mingw test;
     fi
 
-## whitelist
 branches:
   only:
     - master
-    - tmp
+    - next
+    - /^travis.*/
+    - /^tmp.*/

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -52,9 +52,9 @@ fbinmode(FILE *fp)
 	return (fp);
 }
 
-/*
- * Windows has _snprintf() but it does not work like real snprintf().
- */
+/* Microsoft has finally implemented snprintf in Visual Studio 2015 */
+#if defined(_MSC_VER) && _MSC_VER < 1900
+
 int snprintf(char *buf, size_t buflen, const char *format, ...)
 {
 	va_list ap;
@@ -85,3 +85,4 @@ int snprintf(char *buf, size_t buflen, const char *format, ...)
 
 	return outlen;
 }
+#endif


### PR DESCRIPTION
I feel still guilty because I've added the win32 build a few years ago and since then you've probably got one "Still Failing" robot-email after each commit.

So the major motivation of this patch-set is to allow MinGW to fail silently. :)