### PR TITLE
Allow `make install PREFIX=/usr/local` to install globally on a...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Makefile for unifdef
 
-prefix =	${HOME}
-bindir =	${prefix}/bin
-mandir =	${prefix}/share/man
-man1dir=	${mandir}/man1
+PREFIX ?=	${HOME}
+bindir  =	${PREFIX}/bin
+mandir  =	${PREFIX}/share/man
+man1dir =	${mandir}/man1
 
-bindest=	${DESTDIR}${bindir}
-man1dest=	${DESTDIR}${man1dir}
+bindest =	${DESTDIR}${bindir}
+man1dest =	${DESTDIR}${man1dir}
 
 all: unifdef
 


### PR DESCRIPTION
...system, or otherwise change the installation location.

The backstory on this is that I'd like to put `unifdef` into [Homebrew](http://brew.sh/) so it can be available on my Mac OS build systems, which will require a `make install` to put it under `/usr/local`. This won't introduce any modified behavior unless:

    make install PREFIX=/path

is specified.