### PR TITLE
Support C++14 quoted integer literals

### DIFF
--- a/unifdef.c
+++ b/unifdef.c
@@ -1259,6 +1259,12 @@ skipcomment(const char *cp)
 			} else if (strncmp(cp, "//", 2) == 0) {
 				incomment = CXX_COMMENT;
 				cp += 2;
+			/* https://en.cppreference.com/w/cpp/language/integer_literal */
+			} else if ('0' <= cp[0] && cp[0] <= '9' && cp[1] == '\'' &&
+        			   '0' <= cp[2] && cp[2] <= '9') {
+                        	linestate = LS_DIRTY;
+				cp += 2;
+				return (cp);
 			} else if (strncmp(cp, "\'", 1) == 0) {
 				incomment = CHAR_LITERAL;
 				linestate = LS_DIRTY;


### PR DESCRIPTION
Hi,

unifdef works great with my C++20 code base! There is just a minor issue with C++14 quoted integer literals: "Unterminated char literal", e.g. when a C++ source file contains: `int num = 1'000'000;`

 The patch adds support und appears to work fine in my tests. Still it would be great if you could give it a quick review:

When quotes are detected inside an integer literal, the patch skips two characters until after the quote. This seems against the spirit of a function named "skipcomment()", because (part of) an integer literal is skipped, not a comment. Still I believe this should be fine, as the code calling skipcomment() only cares about preprocessor statements, and integer literals are not that. Is this assumption correct?

Best, Zenju