### PR TITLE
tests: support both *BSD and Linux ls -l permissions output

### DIFF
--- a/tests/outperms.sh
+++ b/tests/outperms.sh
@@ -3,7 +3,7 @@ unifdef -DFOO=1 -DFOOB=42 -UBAR -ooutfile.c if1.c
 e=$?
 case ${BUILD_MINGW} in
 (yes)	printf '%s\n' '-rw-r-----' 1>&2 ;;
-(*)	ls -l outfile.c | cut -d' ' -f1 1>&2 ;;
+(*)	ls -l outfile.c | sed 's/[.]\? .*//' 1>&2 ;;
 esac
 cat outfile.c
 rm outfile.c

--- a/tests/overperms.sh
+++ b/tests/overperms.sh
@@ -1,11 +1,11 @@
 cp if1.c outfile.c
 chmod 640 outfile.c
-ls -l outfile.c | cut -d' ' -f1 1>&2
+ls -l outfile.c | sed 's/[.]\? .*//' 1>&2
 unifdef -DFOO=1 -DFOOB=42 -UBAR -m outfile.c
 e=$?
 case ${BUILD_MINGW} in
 (yes)	printf '%s\n' '-rw-r-----' 1>&2 ;;
-(*)	ls -l outfile.c | cut -d' ' -f1 1>&2 ;;
+(*)	ls -l outfile.c | sed 's/[.]\? .*//' 1>&2 ;;
 esac
 cat outfile.c
 rm outfile.c


### PR DESCRIPTION
Linux ls(1) adds trailing '.' to the first -- "drwxrwxrwx" output
column -- a character that does not exist in *BSD ls -l output.

The sed expression 's/[.]\? .*//' removes everything since first
space -- and additionally trailing dot (.) before that if such
a character exists there.