### PR TITLE
Makefile: fix error on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install: unifdef unifdefall.sh unifdef.1
 	: manual
 	install -m 755 -d  ${man1dest}
 	install -m 644 unifdef.1  ${man1dest}/
-	ln -s unifdef.1  ${man1dest}/unifdefall.1
+	ln -f -s unifdef.1  ${man1dest}/unifdefall.1
 
 clean:
 	rm -f unifdef version.h


### PR DESCRIPTION
ln: failed to create symbolic link '/home/thomas/Documents/buildroot/output/host/share/man/man1/unifdefall.1': File exists

Seen while trying to add this package to buildroot.org.

Signed-off-by: Thomas Devoogdt <thomas.devoogdt@barco.com>