### PR TITLE
Don't use C23 constexpr keyword

### DIFF
--- a/unifdef.c
+++ b/unifdef.c
@@ -202,7 +202,7 @@ static int              depth;			/* current #if nesting */
 static int              delcount;		/* count of deleted lines */
 static unsigned         blankcount;		/* count of blank lines */
 static unsigned         blankmax;		/* maximum recent blankcount */
-static bool             constexpr;		/* constant #if expression */
+static bool             is_constexpr;		/* constant #if expression */
 static bool             zerosyms;		/* to format symdepth output */
 static bool             firstsym;		/* ditto */
 
@@ -1086,7 +1086,7 @@ eval_unary(const struct ops *ops, long *valp, const char **cpp)
 			*valp = (value[sym] != NULL);
 			lt = *valp ? LT_TRUE : LT_FALSE;
 		}
-		constexpr = false;
+		is_constexpr = false;
 	} else if (!endsym(*cp)) {
 		debug("eval%d symbol", prec(ops));
 		sym = findsym(&cp);
@@ -1103,7 +1103,7 @@ eval_unary(const struct ops *ops, long *valp, const char **cpp)
 			lt = *valp ? LT_TRUE : LT_FALSE;
 			cp = skipargs(cp);
 		}
-		constexpr = false;
+		is_constexpr = false;
 	} else {
 		debug("eval%d bad expr", prec(ops));
 		return (LT_ERROR);
@@ -1170,10 +1170,10 @@ ifeval(const char **cpp)
 	long val = 0;
 
 	debug("eval %s", *cpp);
-	constexpr = killconsts ? false : true;
+	is_constexpr = killconsts ? false : true;
 	ret = eval_table(eval_ops, &val, cpp);
 	debug("eval = %d", val);
-	return (constexpr ? LT_IF : ret == LT_ERROR ? LT_IF : ret);
+	return (is_constexpr ? LT_IF : ret == LT_ERROR ? LT_IF : ret);
 }
 
 /*


### PR DESCRIPTION
This fixes building with upcoming GCC 15 which defaults to -std=gnu23.